### PR TITLE
Fix can't delete user if not admin

### DIFF
--- a/front/website/ts/components/users/views/users.html
+++ b/front/website/ts/components/users/views/users.html
@@ -10,12 +10,12 @@
 				</div>
 				<md-button class="md-icon-button" aria-label="Change password"
 						ng-click="usersCtrl.startEditUser($event, user)"
-						ng-show="user.IsAdmin">
+						ng-show=" !user.IsAdmin">
 					<ng-md-icon icon="edit"></ng-md-icon>
 				</md-button>
 				<md-button class="md-icon-button md-warn" aria-label="Delete this user"
 						ng-click="usersCtrl.startDeleteUser($event, user)"
-						ng-show="user.IsAdmin">
+						ng-show=" !user.IsAdmin">
 					<ng-md-icon icon="delete"></ng-md-icon>
 				</md-button>
 			</md-list-item>


### PR DESCRIPTION
Condition not displaying edit and delete button was applying for users and not admins. This is the inverted logic we were looking for