### PR TITLE
Creating duplicate user returns an error

### DIFF
--- a/src/users/main.go
+++ b/src/users/main.go
@@ -535,7 +535,9 @@ func postUsers(req nano.Request) (*nano.Response, error) {
 		true,
 	)
 	if err != nil {
-		return nil, err
+		return nano.JSONResponse(409, hash{
+			"error": err.Error(),
+		}), nil
 	}
 
 	return nano.JSONResponse(200, hash{


### PR DESCRIPTION
creating a user with an email already in the databse return the apropriate error